### PR TITLE
Fix doc for subdomains

### DIFF
--- a/context.md
+++ b/context.md
@@ -1070,7 +1070,7 @@ c.Subdomains() []string
 // Example
 // Host: "tobi.ferrets.example.com"
 app.Get("/", func(c *fiber.Ctx) {
-  c.Subdomains(200)
+  c.Subdomains()
   // => ["ferrets", "tobi"]
 })
 ```


### PR DESCRIPTION
The `Subdomains` method has zero args.