### PR TITLE
Fixed "an" "a" usage

### DIFF
--- a/application.md
+++ b/application.md
@@ -6,7 +6,7 @@ description: The app instance conventionally denotes the Fiber application.
 
 ## New
 
-Creates an new Fiber instance named "**app**".
+Creates a new Fiber instance named "**app**".
 
 ```go
 app := fiber.New()


### PR DESCRIPTION
Replaced "Creates an new Fiber instance named "**app**"." with "Creates a new Fiber instance named "**app**"."