### PR TITLE
fix: small type to use redirect meddleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -569,7 +569,7 @@ func main() {
       "/old":   "/new",
       "/old/*": "/new/$1",
     },
-    Status: 301,
+    StatusCode: 301,
   }))
 
   app.Get("/new", func(c *fiber.Ctx) {


### PR DESCRIPTION
In doc was added parameter from config as `Status` but the right way is `StatusCode`