### PR TITLE
Add missing > a the end of c.Format example

### DIFF
--- a/context.md
+++ b/context.md
@@ -392,7 +392,7 @@ app.Get("/", func(c *fiber.Ctx) {
 
   // Accept: text/html
   c.Format("Hello, World!")
-  // => <p>Hello, World!</p
+  // => <p>Hello, World!</p>
 
   // Accept: application/json
   c.Format("Hello, World!")


### PR DESCRIPTION
Just add `>` to close the `<p>` tag in c.Format example.