### PR TITLE
Fix missing opening parentheses

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -137,7 +137,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -461,7 +461,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/ar/middleware.md
+++ b/translations/ar/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/cn/middleware.md
+++ b/translations/cn/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/de/middleware.md
+++ b/translations/de/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/el/middleware.md
+++ b/translations/el/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/es/middleware.md
+++ b/translations/es/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/fa/middleware.md
+++ b/translations/fa/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/fr/middleware.md
+++ b/translations/fr/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/gr/middleware.md
+++ b/translations/gr/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/he/middleware.md
+++ b/translations/he/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/hu/middleware.md
+++ b/translations/hu/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/id/middleware.md
+++ b/translations/id/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/ir/middleware.md
+++ b/translations/ir/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/it/middleware.md
+++ b/translations/it/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/ja/middleware.md
+++ b/translations/ja/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/jp/middleware.md
+++ b/translations/jp/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/ko/middleware.md
+++ b/translations/ko/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/kr/middleware.md
+++ b/translations/kr/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/pl/middleware.md
+++ b/translations/pl/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/pt/middleware.md
+++ b/translations/pt/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/ru/middleware.md
+++ b/translations/ru/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/tr/middleware.md
+++ b/translations/tr/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/vi/middleware.md
+++ b/translations/vi/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )

--- a/translations/zh/middleware.md
+++ b/translations/zh/middleware.md
@@ -135,7 +135,7 @@ compression.New(config ...Config) func(*fiber.Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/compression"
 )
@@ -459,7 +459,7 @@ websocket.New(handler func(*Conn), config ...Config) func(*Ctx)
 ```go
 package main
 
-import 
+import (
   "github.com/gofiber/fiber"
   "github.com/gofiber/websocket"
 )


### PR DESCRIPTION
#94  Missing some opening parentheses at the import level in the Middleware examples for part the compression and webSocket