### PR TITLE
1.14.0

### DIFF
--- a/app.md
+++ b/app.md
@@ -10,7 +10,7 @@ This method creates a new **App** named instance. You can pass optional [setting
 
 {% code title="Signature" %}
 ```go
-fiber.New(settings ...*Settings) *App
+fiber.New(config Config) *App
 ```
 {% endcode %}
 
@@ -21,11 +21,15 @@ package main
 import "github.com/gofiber/fiber"
 
 func main() {
-    app := fiber.New()
+    app := fiber.New(fiber.Config{
+        StrictRouting: true,
+    })
 
     // ...
 
-    app.Listen(3000)
+    if err := app.Listen(":3000"); err != nil {
+        println(err)
+    }
 }
 ```
 {% endcode %}

--- a/app.md
+++ b/app.md
@@ -4,17 +4,16 @@ description: The app instance conventionally denotes the Fiber application.
 
 # 🚀 Application
 
+## Default
+
 ## New
 
-This method creates a new **App** named instance. You can pass optional [settings ](app.md#settings)when creating a new instance
+This method creates a new **App** named instance with a custom configuration.
 
-{% code title="Signature" %}
 ```go
-fiber.New(config Config) *App
+func New(config Config) *App
 ```
-{% endcode %}
 
-{% code title="Example" %}
 ```go
 package main
 
@@ -22,7 +21,10 @@ import "github.com/gofiber/fiber"
 
 func main() {
     app := fiber.New(fiber.Config{
+        Prefork:       true,
+        CaseSensitive: true,
         StrictRouting: true,
+        ServerHeader:  "Fiber",
     })
 
     // ...
@@ -32,11 +34,10 @@ func main() {
     }
 }
 ```
-{% endcode %}
 
-## Settings
+## Config
 
-You can pass application settings when calling `New`.
+When creating a new Fiber instance, you can use different configurations for your application.
 
 {% code title="Example" %}
 ```go


### PR DESCRIPTION
app.Get("/:foo", func(c *fiber.Ctx) {
    result := utils.ImmutableString(c.Param("foo")) 
    // result is now immutable
}

I guess parenthesis is are in-balance 
https://docs.gofiber.io/