### PR TITLE
Update error-handling.md

### DIFF
--- a/error-handling.md
+++ b/error-handling.md
@@ -56,7 +56,7 @@ app.Get("/", func(c *fiber.Ctx) error {
     return fiber.ErrServiceUnavailable
 
     // 503 On vacation!
-    return fiber.NewError(fiber.ErrServiceUnavailable, "On vacation!")
+    return fiber.NewError(fiber.StatusServiceUnavailable, "On vacation!")
 })
 ```
 {% endcode %}


### PR DESCRIPTION
`fiber.NewError`'s first parameter should input status code, instead of `*fiber.Error`.