### PR TITLE
Fix broken session middleware example.

### DIFF
--- a/api/middleware/session.md
+++ b/api/middleware/session.md
@@ -57,7 +57,7 @@ app.Get("/", func(c *fiber.Ctx) error {
         panic(err)
     }
 
-    return fmt.Fprintf(ctx, "Welcome %v", name)
+    return c.SendString(fmt.Sprintf("Welcome %v", name))
 })
 ```
 


### PR DESCRIPTION
Fixed errors:
- use of undeclared `ctx`.
- `fmt.Fprintf` returns 2 variables instead or `error`, so I used the combination of `c.SendString` and `fmt.Sprintf`.