### PR TITLE
Fix type for Context section in docs

### DIFF
--- a/api/ctx.md
+++ b/api/ctx.md
@@ -411,7 +411,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 
 ## Response
 
-Request return the [\*fasthttp.Response](https://godoc.org/github.com/valyala/fasthttp#Response) pointer
+Response return the [\*fasthttp.Response](https://godoc.org/github.com/valyala/fasthttp#Response) pointer
 
 **Signature**
 


### PR DESCRIPTION
Fixed typo where it currently says `Request` when it should say `Response` as it is referring to the `Response()` func