### PR TITLE
Update example for limiter storage

### DIFF
--- a/api/middleware/limiter.md
+++ b/api/middleware/limiter.md
@@ -47,7 +47,7 @@ app.Use(limiter.New(limiter.Config{
     LimitReached: func(c *fiber.Ctx) error {
         return c.SendFile("./toofast.html")
     },
-    Store: myCustomStore{}
+    Storage: myCustomStorage{}
 }))
 ```
 


### PR DESCRIPTION
Example now uses `Storage` instead of the deprecated `Store`