### PR TITLE
fix(guide): incorrect HTTP status code on validation error

### DIFF
--- a/guide/validation.md
+++ b/guide/validation.md
@@ -62,7 +62,7 @@ func AddUser(c *fiber.Ctx) error {
 
     errors := ValidateStruct(*user)
     if errors != nil {
-       return c.JSON(errors)
+       return c.Status(fiber.StatusBadRequest).JSON(errors)
         
     }
 


### PR DESCRIPTION
By default, it sends the `200 OK` status code.
I've replaced it with `400 Bad Request`.