### PR TITLE
Fix comment

### DIFF
--- a/api/middleware/limiter.md
+++ b/api/middleware/limiter.md
@@ -81,7 +81,7 @@ type Config struct {
     // Optional. Default: nil
     Next func(c *fiber.Ctx) bool
 
-    // Max number of recent connections during `Duration` seconds before sending a 429 response
+    // Max number of recent connections during `Expiration` seconds before sending a 429 response
     //
     // Default: 5
     Max int


### PR DESCRIPTION
Change mentioning of deprecated `Duration` to `Expiration`