### PR TITLE
📝Add optional parameter example to routing constraints section

### DIFF
--- a/api/middleware/session.md
+++ b/api/middleware/session.md
@@ -99,7 +99,7 @@ store := session.New(session.Config{
 })
 ```
 
-To use the the store, see the above example.
+To use the store, see the above example.
 
 ## Config
 

--- a/guide/routing.md
+++ b/guide/routing.md
@@ -209,6 +209,24 @@ app.Get("/:date<regex(\\d{4}-\\d{2}-\\d{2})}>", func(c *fiber.Ctx) error {
 You should use `\\` before routing-specific characters when to use datetime constraint (`*`, `+`, `?`, `:`, `/`, `<`, `>`, `;`, `(`, `)`), to avoid wrong parsing.
 {% endhint %}
 
+**Optional Parameter Example**
+
+You can impose constraints on optional parameters as well.
+
+```go
+app.Get("/:test<int>?", func(c *fiber.Ctx) error {
+  return c.SendString(c.Params("test"))
+})
+
+// curl -X GET http://localhost:3000/42
+// 42
+
+// curl -X GET http://localhost:3000/
+//
+
+// curl -X GET http://localhost:3000/7.0
+// Cannot GET /7.0
+```
 
 ## Middleware
 


### PR DESCRIPTION
This PR adds an example of using constraints on an optional parameter as part of gofiber/fiber#2179 and as requested in [this comment](https://github.com/gofiber/fiber/pull/2179#issuecomment-1298163921).