### PR TITLE
Update docs to add URL prefix to pprof middleware

### DIFF
--- a/api/middleware/pprof.md
+++ b/api/middleware/pprof.md
@@ -49,12 +49,12 @@ type Config struct {
     // Optional. Default: nil
     Next func(c *fiber.Ctx) bool
 
-	// Prefix defines a URL prefix added before "/debug/pprof".
-	// Note that it should start with (but not end with) a slash.
-	// Example: "/federated-fiber"
-	//
-	// Optional. Default: ""
-	Prefix string
+    // Prefix defines a URL prefix added before "/debug/pprof".
+    // Note that it should start with (but not end with) a slash.
+    // Example: "/federated-fiber"
+    //
+    // Optional. Default: ""
+    Prefix string
 }
 ```
 

--- a/api/middleware/pprof.md
+++ b/api/middleware/pprof.md
@@ -29,6 +29,16 @@ After you initiate your Fiber app, you can use the following possibilities:
 app.Use(pprof.New())
 ```
 
+In systems where you have multiple ingress endpoints, it is common to add a URL prefix, like so:
+
+```go
+// Default middleware
+app.Use(pprof.New(pprof.Config{Prefix: "/endpoint-prefix"}))
+```
+
+This prefix will be added to the default path of "/debug/pprof/", for a resulting URL of:
+"/endpoint-prefix/debug/pprof/".
+
 ## Config
 
 ```go
@@ -38,6 +48,13 @@ type Config struct {
     //
     // Optional. Default: nil
     Next func(c *fiber.Ctx) bool
+
+	// Prefix defines a URL prefix added before "/debug/pprof".
+	// Note that it should start with (but not end with) a slash.
+	// Example: "/federated-fiber"
+	//
+	// Optional. Default: ""
+	Prefix string
 }
 ```
 


### PR DESCRIPTION
Relates to: https://github.com/gofiber/fiber/pull/2194

## Description

In systems with multiple ingress endpoints all sharing the same load balancer and base URL, it is common to place servers behind a URL prefix. To facilitate this, this PR allows the pprof middleware to define a URL Prefix during configuration so that the endpoints are served on an appropriate URL.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
