### PR TITLE
guide,original: do not use security headers in middleware response

### DIFF
--- a/guide/routing.md
+++ b/guide/routing.md
@@ -218,13 +218,8 @@ Functions that are designed to make changes to the request or response are calle
 
 ```go
 app.Use(func(c *fiber.Ctx) error {
-  // Set some security headers:
-  c.Set("X-XSS-Protection", "1; mode=block")
-  c.Set("X-Content-Type-Options", "nosniff")
-  c.Set("X-Download-Options", "noopen")
-  c.Set("Strict-Transport-Security", "max-age=5184000")
-  c.Set("X-Frame-Options", "SAMEORIGIN")
-  c.Set("X-DNS-Prefetch-Control", "off")
+  // Set a custom header on all responses:
+  c.Set("X-Custom-Header", "Hello, World")
 
   // Go to next middleware:
   return c.Next()

--- a/original/routing.md
+++ b/original/routing.md
@@ -67,13 +67,8 @@ Functions, that are designed to make changes to the request or response, are cal
 
 ```go
 app.Use(func(c *fiber.Ctx) {
-  // Set some security headers:
-  c.Set("X-XSS-Protection", "1; mode=block")
-  c.Set("X-Content-Type-Options", "nosniff")
-  c.Set("X-Download-Options", "noopen")
-  c.Set("Strict-Transport-Security", "max-age=5184000")
-  c.Set("X-Frame-Options", "SAMEORIGIN")
-  c.Set("X-DNS-Prefetch-Control", "off")
+  // Set a custom header on all responses:
+  c.Set("X-Custom-Header", "Hello, World")
 
   // Go to next middleware:
   c.Next()


### PR DESCRIPTION
The unaware user might end up reusing the example code. Instead, users should refer to e.g. https://github.com/gofiber/helmet for security-relevant headers.