### PR TITLE
:memo: middleware/filesystem does not handle url encoded values

### DIFF
--- a/api/middleware/filesystem.md
+++ b/api/middleware/filesystem.md
@@ -2,7 +2,8 @@
 
 Filesystem middleware for [Fiber](https://github.com/gofiber/fiber) that enables you to serve files from a directory.
 
-⚠️ **`:params` & `:optionals?` within the prefix path are not supported!**
+⚠️ **`:params` & `:optionals?` within the prefix path are not supported!**  
+⚠️ **To handle paths with spaces (or other url encoded values) make sure to set `fiber.Config{ UnescapePath: true}`**
 
 ### Table of Contents
 


### PR DESCRIPTION
related to https://github.com/gofiber/fiber/pull/2247