### PR TITLE
Update method signature of `Locals()` to match latest release

### DIFF
--- a/api/ctx.md
+++ b/api/ctx.md
@@ -894,7 +894,7 @@ This is useful if you want to pass some **specific** data to the next middleware
 
 {% code title="Signature" %}
 ```go
-func (c *Ctx) Locals(key string, value ...interface{}) interface{}
+func (c *Ctx) Locals(key interface{}, value ...interface{}) interface{}
 ```
 {% endcode %}
 


### PR DESCRIPTION
The main package received an update in v2.40.0 that changed a method signature but did not update the documentation to match.

https://github.com/gofiber/fiber/commit/ff4602980a2a88b4a543641714716e7a348b3007

Fixes https://github.com/gofiber/docs/issues/307

I didn't find any contributing guide, so please let me know if there's anything else y'all need. :)