### PR TITLE
📝 docs(filesystem): fix statik filesystem middleware example typo

### DIFF
--- a/docs/api/middleware/filesystem.md
+++ b/docs/api/middleware/filesystem.md
@@ -162,27 +162,27 @@ func main() {
 package main
 
 import (
-    "github.com/gofiber/fiber/v2"
-    "github.com/gofiber/fiber/v2/middleware/filesystem"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/filesystem"
 
-    "<Your go module>/statik"
-    fs "github.com/rakyll/statik/fs"
+	// Use blank to invoke init function and register data to statik
+	_ "<Your go module>/statik" 
+	"github.com/rakyll/statik/fs"
 )
 
 func main() {
-    statik, err := fs.New()
-    if err != nil {
-        panic(err)
-    }
+	statikFS, err := fs.New()
+	if err != nil {
+		panic(err)
+	}
 
-    app := fiber.New()
+	app := fiber.New()
 
-    app.Use("/", filesystem.New(filesystem.Config{
-        Root: statikFS,
-    })
+	app.Use("/", filesystem.New(filesystem.Config{
+		Root: statikFS,
+	}))
 
-    log.Fatal(app.Listen(":3000"))
-}
+	log.Fatal(app.Listen(":3000"))
 ```
 
 ### Config


### PR DESCRIPTION
syncing from official repo PRs:

- [docs(filesystem): fix statik filesystem middleware example typo](https://github.com/gofiber/fiber/pull/2302)
- [docs(filesystem): clean duplicated namespace for example](https://github.com/gofiber/fiber/pull/2313)