### PR TITLE
docs: update docs for fiber PR #2486

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -24,13 +24,16 @@ func (c *Ctx) AcceptsLanguages(offers ...string) string
 ```
 
 ```go title="Example"
-// Accept: text/*, application/json
+// Accept: text/html, application/json; q=0.8, text/plain; q=0.5; charset="utf-8"
 
 app.Get("/", func(c *fiber.Ctx) error {
   c.Accepts("html")             // "html"
   c.Accepts("text/html")        // "text/html"
   c.Accepts("json", "text")     // "json"
   c.Accepts("application/json") // "application/json"
+  c.Accepts("text/plain", "application/json") // "application/json", due to quality
+  c.Accepts("text/plain", "application/json") // "application/json", due to specificity
+  c.Accepts("text/html", "application/json") // "text/html", due to first match
   c.Accepts("image/png")        // ""
   c.Accepts("png")              // ""
   // ...


### PR DESCRIPTION
# Don't Send a PR to Update Docs Files

We are no longer accepting doc files changes in the **gofiber/docs** repo. Please submit your pull requests to https://github.com/gofiber/fiber instead. Any PR that edits documentations won't be accepted in this repository.
