### PR TITLE
chore: adjust donate url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -226,7 +226,7 @@ const config = {
                         }],
                     },
                     {
-                        to: 'https://gofiber.io/support',
+                        to: 'https://buymeacoffee.com/fenny',
                         label: '☕ Donate',
                         position: 'left',
                     },


### PR DESCRIPTION
This pull request resolves a broken URL found in the "Donate" navigation menu.

I decided to open this PR after noticing that the docusaurus.config.json file was missing from the docs directory in the main branch (https://github.com/gofiber/fiber/tree/main/docs). 