### PR TITLE
feat: apply theme before content to avoid flash

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,6 +11,7 @@ const isDocs = BUILD_TARGET === 'docs';
 
 function plugins(): PluginConfig[] {
     let pluginList: PluginConfig[] = [
+        require.resolve('./no-flash-color-mode-plugin.js'),
         'docusaurus-plugin-sass',
     ];
     

--- a/no-flash-color-mode-plugin.js
+++ b/no-flash-color-mode-plugin.js
@@ -1,0 +1,38 @@
+export default function noFlashColorModePlugin(context) {
+  const defaultMode = context.siteConfig.themeConfig?.colorMode?.defaultMode ?? 'light';
+  const respectPrefers = context.siteConfig.themeConfig?.colorMode?.respectPrefersColorScheme ?? false;
+  return {
+    name: 'no-flash-color-mode-plugin',
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'script',
+            innerHTML: `(function() {
+  var defaultMode = '${defaultMode}';
+  var respectPrefersColorScheme = ${respectPrefers};
+  var storageKey = 'theme';
+  function getStoredTheme() {
+    try {
+      return window.localStorage.getItem(storageKey);
+    } catch (e) {
+      return null;
+    }
+  }
+  function getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  var storedTheme = getStoredTheme();
+  var theme = storedTheme || (respectPrefersColorScheme ? getSystemTheme() : defaultMode);
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.setAttribute('data-theme-choice', storedTheme || (respectPrefersColorScheme ? 'system' : defaultMode));
+  var bg = theme === 'dark' ? '#1b1b1d' : '#ffffff';
+  document.documentElement.style.backgroundColor = bg;
+  document.documentElement.style.colorScheme = theme;
+})();`,
+          },
+        ],
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- inject early theme script to set `data-theme` and background before app load
- register new plugin so user/system theme is applied without white flash

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899e439c0908326ab48ce1f625d9d3a