### PR TITLE
Fix dark mode flash by hiding page until theme set

### DIFF
--- a/no-flash-color-mode-plugin.js
+++ b/no-flash-color-mode-plugin.js
@@ -7,6 +7,10 @@ export default function noFlashColorModePlugin(context) {
       return {
         headTags: [
           {
+            tagName: 'style',
+            innerHTML: `html { visibility: hidden; } html[data-theme] { visibility: visible; }`,
+          },
+          {
             tagName: 'script',
             innerHTML: `(function() {
   var defaultMode = '${defaultMode}';
@@ -22,12 +26,12 @@ export default function noFlashColorModePlugin(context) {
   function getSystemTheme() {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
-  var storedTheme = getStoredTheme();
-  var theme = storedTheme || (respectPrefersColorScheme ? getSystemTheme() : defaultMode);
-  document.documentElement.setAttribute('data-theme', theme);
-  document.documentElement.setAttribute('data-theme-choice', storedTheme || (respectPrefersColorScheme ? 'system' : defaultMode));
-  document.documentElement.style.colorScheme = theme;
-})();`,
+    var storedTheme = getStoredTheme();
+    var theme = storedTheme || (respectPrefersColorScheme ? getSystemTheme() : defaultMode);
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute('data-theme-choice', storedTheme || (respectPrefersColorScheme ? 'system' : defaultMode));
+    document.documentElement.style.colorScheme = theme;
+  })();`,
           },
         ],
       };


### PR DESCRIPTION
## Summary
- hide page until theme is applied to avoid white flash

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b1bf5c1e08326a6d5de32f43d7d6a