### PR TITLE
Enable horizontal scrolling for wide tables on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,6 +75,16 @@ table {
   display: table;
 }
 
+@media (max-width: 768px) {
+  /* Allow wide tables to scroll horizontally on narrow screens */
+  table {
+    width: auto;
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
 .margin-between > *:not(:first-child) {
     margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- allow wide tables to scroll horizontally on narrow screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Unable to build website; loading of version failed)


------
https://chatgpt.com/codex/tasks/task_e_68a95c6f1f908326acb97b2961567729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tables on small screens now support horizontal scrolling, ensuring wide content remains accessible on phones and tablets. Touch devices benefit from smooth, native momentum scrolling. No impact on desktop layouts.

* **Style**
  * Improved responsive table styling for viewports under 768px by switching to a scrollable block layout, preserving readability without squeezing columns or reducing text size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->