### PR TITLE
Fix color scheme when toggling from dark to light mode

### DIFF
--- a/no-flash-color-mode-plugin.js
+++ b/no-flash-color-mode-plugin.js
@@ -31,11 +31,17 @@ export default function noFlashColorModePlugin(context) {
     document.documentElement.setAttribute('data-theme', theme);
     document.documentElement.setAttribute('data-theme-choice', storedTheme || (respectPrefersColorScheme ? 'system' : defaultMode));
     document.documentElement.style.colorScheme = theme;
+    if (document.body) {
+      document.body.style.colorScheme = theme;
+    }
 
     var observer = new MutationObserver(function() {
       var newTheme = document.documentElement.getAttribute('data-theme');
       if (newTheme) {
         document.documentElement.style.colorScheme = newTheme;
+        if (document.body) {
+          document.body.style.colorScheme = newTheme;
+        }
       }
     });
 

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,37 @@
+import React, {type PropsWithChildren, useEffect} from 'react';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+function applyColorScheme(nextTheme: string | null | undefined) {
+  if (!ExecutionEnvironment.canUseDOM || !nextTheme) {
+    return;
+  }
+
+  const resolvedTheme = nextTheme === 'dark' ? 'dark' : 'light';
+  document.documentElement.style.colorScheme = resolvedTheme;
+  if (document.body) {
+    document.body.style.colorScheme = resolvedTheme;
+  }
+}
+
+export default function Root({children}: PropsWithChildren): JSX.Element {
+  useEffect(() => {
+    if (!ExecutionEnvironment.canUseDOM) {
+      return undefined;
+    }
+
+    applyColorScheme(document.documentElement.getAttribute('data-theme'));
+
+    const observer = new MutationObserver(() => {
+      applyColorScheme(document.documentElement.getAttribute('data-theme'));
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- update the no-flash color mode plugin to watch for theme changes and keep the document color scheme in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea3d8041a48326ae133482cf724912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ensures the site’s color-scheme is consistently applied to all page elements (including browser/OS-rendered UI) and updates dynamically when the theme changes.
* **Bug Fixes**
  * Eliminates light/dark flicker by syncing the color scheme on initial load and immediately after theme changes, improving contrast and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->