### PR TITLE
Add 'toml' to additionalLanguages in prism config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -441,7 +441,7 @@ const config: Config = {
             prism: {
                 theme: lightCodeTheme,
                 darkTheme: darkCodeTheme,
-                additionalLanguages: ['json', 'diff', 'go', 'toml'],
+                additionalLanguages: ['diff', 'go', 'json', 'toml', 'yaml'],
             },
             inkeepConfig: {
                 chatButtonType: 'PILL', // RECTANGLE_SHORTCUT, ICON, or PILL


### PR DESCRIPTION
TOML code highlighting is missing and can be enabled via Prism

<img width="1135" height="358" alt="image" src="https://github.com/user-attachments/assets/cb906beb-a6ce-4c9e-9af7-33e653f0fbc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TOML and YAML syntax highlighting for code examples in documentation, improving readability for configuration and technical content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->