### PR TITLE
Add dependabot group for react and react-dom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
         patterns:
           - "@docusaurus/*"
           - "docusaurus"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:


### PR DESCRIPTION
Group react and react-dom dependency updates together so they are
always bumped in a single PR, avoiding version mismatches.

https://claude.ai/code/session_01PvGwxASSA3kFKYeefE2Ko3