### PR TITLE
docs(core): note the HTTP/2 (gRPC) "id <= evictCount" symptom in Zero Allocation

### DIFF
--- a/docs/core/intro.md
+++ b/docs/core/intro.md
@@ -152,6 +152,17 @@ app := fiber.New(fiber.Config{
 
 For details, see [Immutable](./api/fiber.md#immutable) in the configuration reference and the [GetString and GetBytes](./api/app.md#getstring) helpers.
 
+A common way to run into this is forwarding a context value (for example a header from `c.Get`) into the metadata of a long-lived **gRPC / HTTP-2 client**. The value is retained in the connection's HTTP/2 HPACK table and later mutated when the request buffer is reused, crashing the process with a panic in code you don't own:
+
+```text
+panic: id (N) <= evictCount (M)
+    golang.org/x/net/http2/hpack.(*headerFieldTable).idToIndex
+    ...
+    google.golang.org/grpc/internal/transport.(*loopyWriter).writeHeader
+```
+
+The Go race detector does not catch it, because the corruption happens inside a single gRPC writer goroutine. Copy the value or enable `Immutable` (as shown above) before handing it to anything that outlives the handler. See [#4464](https://github.com/gofiber/fiber/issues/4464) for a full reproduction.
+
 ## Explore the Ecosystem
 
 Fiber is more than the core module. When your application grows, these officially maintained building blocks are one import away:


### PR DESCRIPTION
Minimal, docs-only addition requested in gofiber/fiber#4464.

The **Zero Allocation** section already explains the cause and the fix (`copy` / `Immutable`). This adds the **symptom** — the `panic: id (N) <= evictCount (M)` from `golang.org/x/net/http2/hpack` — so that people who hit it can find the existing guidance via search.

When a context value (e.g. a header from `c.Get`) is forwarded into a long-lived **gRPC / HTTP-2 client's** metadata, it is retained in the HTTP/2 HPACK dynamic table and later mutated when the request buffer is reused, crashing the process. The panic surfaces in an unrelated package with no mention of Fiber, so the recurring outcome is a re-filed issue (gofiber/fiber#2067 and others) or people switching frameworks.

Behaviour and the documented contract are unchanged — this is purely a searchable signpost back to what the section already documents.

Refs gofiber/fiber#4464. A full self-contained reproduction (panics in seconds; `copy` / `Immutable` fix it) is linked from the issue.