### PR TITLE
feat(home): add go get install command to hero snippet

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -5,6 +5,8 @@ import shared from './shared.module.scss';
 import BrowserWindow from './BrowserWindow';
 import LatestRelease from './LatestRelease';
 
+const installCode = `go get github.com/gofiber/fiber/v3`;
+
 const exampleCode = `package main
 
 import (
@@ -53,7 +55,12 @@ export default function Hero() {
 
                 <div className={styles.heroExample}>
                     <div className={styles.codeCol}>
-                        <CodeBlock language="go">{exampleCode}</CodeBlock>
+                        <CodeBlock language="bash" title="Terminal">
+                            {installCode}
+                        </CodeBlock>
+                        <CodeBlock language="go" title="main.go">
+                            {exampleCode}
+                        </CodeBlock>
                     </div>
                     <div className={styles.arrow}>→</div>
                     <div className={styles.previewCol}>


### PR DESCRIPTION
## What does this PR change?

Adds the `go get github.com/gofiber/fiber/v3` installation snippet directly above the starter `main.go` example code on the homepage hero section (`gofiber.io`).

This makes the hero example self-contained so developers landing on the homepage can immediately know how to install the dependency before running the boilerplate.

Closes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a terminal code block showing the command to install the package.
  * Updated the Go example with a clearer `main.go` title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->